### PR TITLE
Add ship ids

### DIFF
--- a/tests/gameboard.test.js
+++ b/tests/gameboard.test.js
@@ -17,9 +17,7 @@ test('places ship at coordinates', () => {
   expect(gameboard.placeShip(ship, [0, 0], 'row').coordinates[0][3])
     .toEqual(expect.objectContaining({
       status: 'filled',
-      ship: expect.objectContaining({
-        length: 4,
-      }),
+      ship: expect.any(Number),
     }));
 });
 

--- a/tests/ship.test.js
+++ b/tests/ship.test.js
@@ -12,8 +12,8 @@ test('has a length', () => {
 
 test('hit() increases number of hits', () => {
   const ship = new Ship(5);
-  const clone = ship.hit(4);
-  expect(clone.hits).toBe(1);
+  const clone = ship.hit().hit();
+  expect(clone.hits).toBe(2);
 });
 
 test('sunk detects sunken ships', () => {


### PR DESCRIPTION
We now use array indices instead of direct object references so that our ships are only ever referenced from one place